### PR TITLE
fix(storage): resource argument name change

### DIFF
--- a/storage_account.tf
+++ b/storage_account.tf
@@ -3,16 +3,16 @@
 resource "azurerm_storage_account" "pgsql" {
   count = (var.diagnostics != null) && var.kv_pointer_enable ? 0 : 1
 
-  name                      = substr("${replace(var.name, "-", "")}pgsql", 0, 24)
-  location                  = var.location
-  resource_group_name       = var.resource_group
-  account_kind              = "StorageV2"
-  account_tier              = "Standard"
-  account_replication_type  = "LRS"
-  access_tier               = "Hot"
-  enable_https_traffic_only = true
-  allow_blob_public_access  = false
-  min_tls_version           = "TLS1_2"
+  name                            = substr("${replace(var.name, "-", "")}pgsql", 0, 24)
+  location                        = var.location
+  resource_group_name             = var.resource_group
+  account_kind                    = "StorageV2"
+  account_tier                    = "Standard"
+  account_replication_type        = "LRS"
+  access_tier                     = "Hot"
+  enable_https_traffic_only       = true
+  allow_nested_items_to_be_public = false
+  min_tls_version                 = "TLS1_2"
 
   network_rules {
     default_action             = var.vnet_create == null ? "Allow" : "Deny"


### PR DESCRIPTION
The allow_blob_public_access  attribute within the azurerm_storage_account Terraform resource no longer exists. The attribute has been renamed to allow_nested_items_to_be_public. The change is documented within the following link https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/3.0-upgrade-guide. 