### PR TITLE
fix(vnet): virtual network resource location assigned to wrong variable

### DIFF
--- a/virtual_network.tf
+++ b/virtual_network.tf
@@ -9,7 +9,7 @@ resource "azurerm_virtual_network" "pgsql" {
   count = (var.vnet_create == true) ? 1 : 0
 
   name                = var.vnet_name
-  location            = var.vnet_rg
+  location            = var.location
   resource_group_name = var.resource_group
   address_space       = [var.vnet_cidr]
 }


### PR DESCRIPTION
This merge request fixes a typo which sets the location of a virtual network to the var.vnet_rg Terraform variable. 